### PR TITLE
fzf.rb: correctly detect the binary

### DIFF
--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -23,7 +23,7 @@ module Cani
 
     def self.executable?
       @exe ||= begin
-        `command -v fzf`
+        `command -v fzf;`.chomp
         $?.success?
       end
     end


### PR DESCRIPTION
Usually, since 'command' is a builtin, `command -v fzf` will give a
Errno::ENOENT: No such file or directory - command

Add a ';' to force `...` to launch the shell, where 'command' will be a
builtin.

And add a 'chomp' to remove the extra new line.