### PR TITLE
Patch/fzf detection

### DIFF
--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -22,10 +22,7 @@ module Cani
     end
 
     def self.executable?
-      @exe ||= begin
-        `command -v fzf;`.chomp
-        $?.success?
-      end
+      @exe ||= !system('fzf --version').nil?
     end
 
     def self.feature_rows

--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -23,7 +23,7 @@ module Cani
 
     def self.executable?
       @exe ||= begin
-        `command -v fzf`
+        `command -v fzf;`.chomp
         $?.success?
       end
     end


### PR DESCRIPTION
Based on the changes made in #1.

The `system` command returns `nil` when execution fails. Since there is no One True Way(tm) for this I think running `system` is the safest way and best of all, it abstracts away the exit-code checking in the process.