### PR TITLE
Use default color for titles in all fzf screens

### DIFF
--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -32,18 +32,20 @@ module Cani
         tt = format('%-24s', ft.title.size > 24 ? ft.title[0..23].strip + '..'
                                                 : ft.title)
 
-        [{content: "[#{ft.status}]", color: cl}, pc, tt, *ft.current_support]
+        [{content: "[#{ft.status}]", color: cl}, pc,
+         {content: tt, color: :default}, *ft.current_support]
       end
     end
 
     def self.browser_rows
       @browser_rows ||= Cani.api.browsers.map do |bwsr|
-        [bwsr.title, 'usage: ' + format('%.4f%%', bwsr.usage.values.reduce(0) { |total, add| total + add })]
+        [{content: bwsr.title, color: :default},
+         'usage: ' + format('%.4f%%', bwsr.usage.values.reduce(0) { |total, add| total + add })]
       end
     end
 
     def self.browser_usage_rows(brwsr)
-      brwsr.usage.map { |(v, u)| [v, 'usage: ' + format('%.4f%%', u)] }.reverse
+      brwsr.usage.map { |(v, u)| [{content: v, color: :default}, 'usage: ' + format('%.4f%%', u)] }.reverse
     end
 
     def self.browser_feature_rows(brwsr, version)
@@ -54,7 +56,7 @@ module Cani
           features.map do |feature|
             color = {'un' => :yellow, 'ot' => :magenta}.fetch feature[:status], :green
             [{content: "[#{feature[:status]}]", color: color},
-             "[#{type[:symbol]}]", feature[:title]]
+             "[#{type[:symbol]}]", {content: feature[:title], color: :default}]
           end
         end
       end.compact


### PR DESCRIPTION
Resolves #2 by using the "default" terminal foreground color.

Apparently this color detection thing is [harder](https://unix.stackexchange.com/questions/172548/how-to-determine-the-current-color-of-the-console-output) than [it seems](https://stackoverflow.com/questions/37401331/why-cant-i-access-my-bash-prompt-in-a-ruby-script) at first glance, I looked in to it for a bit but eventually decided on this instead.

It basically comes down to this: A script has no idea which color codes are being used. We can send escape sequences that get parsed and colorized but there is no mechanism to request the colors instead of setting them.

The improvement is quite significant.

**Before**

![image](https://user-images.githubusercontent.com/3225058/46434769-e2242500-c754-11e8-8f0f-2483f0e6c2ec.png)

**After**

![image](https://user-images.githubusercontent.com/3225058/46434745-ca4ca100-c754-11e8-951d-5aedb3234fdf.png)
