### PR TITLE
cani use opens filtered fzf window when multiple results are present

### DIFF
--- a/lib/cani/api.rb
+++ b/lib/cani/api.rb
@@ -62,6 +62,15 @@ module Cani
       features[idx] if idx
     end
 
+    def find_features(name)
+      name = Regexp.new name.to_s.downcase.gsub(/(\W)/, '.*'), :i
+      features.select do |ft|
+        ft.title.downcase.match(name) ||
+        ft.name.downcase.match(name)  ||
+        ft.description.downcase.match(name)
+      end
+    end
+
     def find_browser(name)
       name = name.to_s.downcase
       idx  = browsers.find_index do |bwsr|

--- a/lib/cani/api/feature.rb
+++ b/lib/cani/api/feature.rb
@@ -1,7 +1,7 @@
 module Cani
   class Api
     class Feature
-      attr_reader :title, :status, :spec, :stats, :percent, :name, :browser_note_nums, :notes, :notes_by_num
+      attr_reader :title, :status, :spec, :stats, :percent, :name, :browser_note_nums, :notes, :notes_by_num, :description
 
       STATUSES = {
         'rec'   => 'rc',
@@ -20,12 +20,13 @@ module Cani
       }.freeze
 
       def initialize(attributes = {})
-        @name    = attributes[:name].to_s.downcase
-        @title   = attributes['title']
-        @status  = STATUSES.fetch attributes['status'], attributes['status']
-        @spec    = attributes['spec']
-        @percent = attributes['usage_perc_y']
-        @notes   = attributes['notes'].split "\n"
+        @name         = attributes[:name].to_s.downcase
+        @title        = attributes['title']
+        @description  = attributes['description']
+        @status       = STATUSES.fetch attributes['status'], attributes['status']
+        @spec         = attributes['spec']
+        @percent      = attributes['usage_perc_y']
+        @notes        = attributes['notes'].split "\n"
         @notes_by_num = attributes['notes_by_num']
         @stats, @browser_note_nums = attributes['stats'].each_with_object([{}, {}]) do |(browser, info), (stts, notes)|
           stts[browser], notes[browser] = info.each_with_object([{}, {}]) do |(version, stat), (st, nt)|

--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -26,15 +26,17 @@ module Cani
     end
 
     def self.feature_rows
-      @feature_rows ||= Cani.api.features.map do |ft|
-        pc = format('%.2f%%', ft.percent).rjust 6
-        cl = {'un' => :yellow, 'ot' => :magenta}.fetch ft.status, :green
-        tt = format('%-24s', ft.title.size > 24 ? ft.title[0..23].strip + '..'
-                                                : ft.title)
+      @feature_rows ||= Cani.api.features.map(&Fzf.method(:to_feature_row))
+    end
 
-        [{content: "[#{ft.status}]", color: cl}, pc,
-         {content: tt, color: :default}, *ft.current_support]
-      end
+    def self.to_feature_row(ft)
+      pc = format('%.2f%%', ft.percent).rjust 6
+      cl = {'un' => :yellow, 'ot' => :magenta}.fetch ft.status, :green
+      tt = format('%-24s', ft.title.size > 24 ? ft.title[0..23].strip + '..'
+                                              : ft.title)
+
+      [{content: "[#{ft.status}]", color: cl}, pc,
+       {content: tt, color: :default}, *ft.current_support]
     end
 
     def self.browser_rows

--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -9,10 +9,11 @@ module Cani
 
         rows   = tableize_rows(rows, **opts).join "\n"
         ohdr   = opts.fetch :header, []
+        query  = "--query=\"#{opts[:query]}\"" if opts[:query]
         header = ohdr.is_a?(Array) ? [:cani, *ohdr].map { |v| v.to_s.downcase }.join(':')
                                    : 'cani:' + ohdr.to_s
 
-        `echo "#{rows}" | fzf --ansi --header="[#{header}]"`.split '   '
+        `echo "#{rows}" | fzf --ansi --header="[#{header}]" #{query}`.split '   '
       else
         # when output of any initial command is being piped
         # print results and exit this command.


### PR DESCRIPTION
When `cani use` finds multiple matches for given search query, it will show fzf with the features that matched either in the _name_, _title_, or _description_ instead of the first match it can find. (here, only 4 out of 466 results match shadow)

![image](https://user-images.githubusercontent.com/3225058/46572177-a4581400-c981-11e8-8266-704487a2e212.png)
