### PR TITLE
system no longer prints version in tty

### DIFF
--- a/lib/cani/fzf.rb
+++ b/lib/cani/fzf.rb
@@ -22,7 +22,7 @@ module Cani
     end
 
     def self.executable?
-      @exe ||= !system('fzf --version').nil?
+      @exe ||= system 'fzf --version > /dev/null 2>&1'
     end
 
     def self.feature_rows


### PR DESCRIPTION
Related to #3.

As seen in #5, when running a command the `system` call checking if `fzf --version` can be executed actually prints the version to the terminal. This patch fixes that issue by redirecting output of the command to `/dev/null` since `system` uses a programs _exit code_ to check for failure of execution.