### PR TITLE
Fix showing help when no command was issued

### DIFF
--- a/lib/cani.rb
+++ b/lib/cani.rb
@@ -24,7 +24,7 @@ module Cani
   end
 
   def self.exec!(command, *args_and_options)
-    return config if command.start_with? '-'
+    return config if command&.start_with? '-'
 
     args    = args_and_options.reject { |arg| arg.start_with? '-' }
     command = :help unless command && respond_to?(command)


### PR DESCRIPTION
Discovered in #12 that running `cani` without arguments would crash. This fix safe-guards for `nil` which allows the default "show help" behavior to work as intended.